### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To see how to use this package in your project, check out our comprehensive exam
 Clone the repository and install all dependencies using Yarn.
 
 ```bash
-git clone https://github.com/ainetwork/ain-adk-providers.git
+git clone https://github.com/ainetwork-ai/ain-adk-providers.git
 cd ain-adk-providers
 yarn install
 ```


### PR DESCRIPTION
This pull request updates the repository URL in the `README.md` to reflect the correct GitHub organization.

- Documentation update:
  * Changed the repository clone URL in the setup instructions from `ainetwork` to `ainetwork-ai` to ensure users clone from the correct source.doc/jiwoo/fix_typo_in_readme

git clone 안되는 이슈