### PR TITLE
Fix: azure model no tool call without tools

### DIFF
--- a/packages/models/azure/index.ts
+++ b/packages/models/azure/index.ts
@@ -101,7 +101,7 @@ export class AzureOpenAI extends BaseModel<CCMessageParam, ChatCompletionTool> {
 				model: this.modelName,
 				messages,
 				tools: functions,
-				tool_choice: "auto",
+				tool_choice: functions.length > 0 ? "auto" : "none",
 			});
 
 			const { content, tool_calls } = response.choices[0].message;
@@ -132,7 +132,7 @@ export class AzureOpenAI extends BaseModel<CCMessageParam, ChatCompletionTool> {
 			model: this.modelName,
 			messages,
 			tools: functions,
-			tool_choice: "auto",
+			tool_choice: functions.length > 0 ? "auto" : "none",
 			stream: true,
 		});
 		return this.createOpenAIStreamAdapter(stream);


### PR DESCRIPTION
Update
- 등록된 tool이 하나도 없을 때에는 tool call을 사용하지 않도록 합니다.

tool 이 없어도 tool 을 선택하려하는 할루시네이션 방지를 위해 수정합니다.