### PR TITLE
Fix/seonghwa/mongodb connection pool

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
       "Read(//Users/shyun/comcom/ain-agent/ain-adk/src/types/**)",
       "Read(//Users/shyun/comcom/ain-agent/ain-adk/src/**)",
       "Bash(npx tsc --noEmit)",
-      "Bash(find /Users/shyun/comcom/ain-agent/ain-adk-providers/packages/auth -name \"*.ts\" -path \"*/implements/*\" -exec basename {} \\\\;)"
+      "Bash(find /Users/shyun/comcom/ain-agent/ain-adk-providers/packages/auth -name \"*.ts\" -path \"*/implements/*\" -exec basename {} \\\\;)",
+      "Bash(node -e ' *)"
     ]
   }
 }

--- a/packages/memory/mongodb/implements/base.memory.ts
+++ b/packages/memory/mongodb/implements/base.memory.ts
@@ -51,7 +51,9 @@ export class MongoDBMemory implements IMemory {
       this.threadTTLSeconds = cfg.threadTTLSeconds;
     }
     this.connectionConfig = {
-      maxPoolSize: cfg.maxPoolSize ?? 1,
+      maxPoolSize: cfg.maxPoolSize ?? 10,
+      minPoolSize: 0,
+      maxIdleTimeMS: 30000,
       serverSelectionTimeoutMS: cfg.serverSelectionTimeoutMS ?? 30000,
       socketTimeoutMS: cfg.socketTimeoutMS ?? 45000,
       connectTimeoutMS: cfg.connectTimeoutMS ?? 30000,
@@ -152,7 +154,7 @@ export class MongoDBMemory implements IMemory {
 
     this.reconnecting = true;
 
-    while (this.reconnectAttempts < this.maxReconnectAttempts && !this.isConnected) {
+    while (this.reconnectAttempts < this.maxReconnectAttempts && !this.connected) {
       this.reconnectAttempts++;
       loggers.agent.info(
         `Attempting to reconnect to MongoDB (${this.reconnectAttempts}/${this.maxReconnectAttempts})...`
@@ -181,7 +183,7 @@ export class MongoDBMemory implements IMemory {
 
     this.reconnecting = false;
 
-    if (!this.isConnected) {
+    if (!this.connected) {
       loggers.agent.error(
         `Failed to reconnect to MongoDB after ${this.maxReconnectAttempts} attempts`
       );
@@ -206,7 +208,7 @@ export class MongoDBMemory implements IMemory {
   }
 
   public async disconnect(): Promise<void> {
-    if (!this.isConnected) {
+    if (!this.connected) {
       return;
     }
 
@@ -228,7 +230,7 @@ export class MongoDBMemory implements IMemory {
   }
 
   private async ensureConnection(): Promise<void> {
-    if (!this.isConnected && !this.reconnecting) {
+    if (!this.connected && !this.reconnecting) {
       await this.connect();
     }
 
@@ -239,7 +241,7 @@ export class MongoDBMemory implements IMemory {
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
 
-    if (!this.isConnected) {
+    if (!this.connected) {
       throw new Error("MongoDB is not connected and reconnection failed");
     }
   }
@@ -336,6 +338,30 @@ export class MongoDBMemory implements IMemory {
       if (error.code === 50 || error.message?.includes("operation exceeded time limit")) {
         loggers.agent.error(`${operationName} exceeded time limit`);
         throw error;
+      }
+
+      // Check if it's a TooManyLogicalSessions error
+      if (error.code === 261 || error.codeName === "TooManyLogicalSessions") {
+        loggers.agent.warn(
+          `${operationName} failed due to too many sessions, disconnecting to release sessions...`
+        );
+
+        try {
+          await mongoose.disconnect();
+          this.connected = false;
+        } catch (disconnectError) {
+          loggers.agent.error("Failed to disconnect during session cleanup:", disconnectError);
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        await this.ensureConnection();
+
+        try {
+          return await operation();
+        } catch (retryError: any) {
+          loggers.agent.error(`${operationName} failed after session cleanup retry:`, retryError);
+          throw retryError;
+        }
       }
 
       // Check if it's a connection-related error

--- a/packages/memory/mongodb/implements/thread.memory.ts
+++ b/packages/memory/mongodb/implements/thread.memory.ts
@@ -88,18 +88,20 @@ export class MongoDBThread implements IThreadMemory {
     messages: MessageObject[]
   ): Promise<void> {
     return this.executeWithRetry(async () => {
-      await ThreadModel.updateOne({ threadId, userId }, { $set: {} });
-      for (const message of messages) {
-        await MessageModel.create({
-          threadId,
-          messageId: message.messageId,
-          userId,
-          role: message.role,
-          content: message.content,
-          timestamp: message.timestamp,
-          metadata: message.metadata,
-        });
-      }
+      const docs = messages.map((message) => ({
+        threadId,
+        messageId: message.messageId,
+        userId,
+        role: message.role,
+        content: message.content,
+        timestamp: message.timestamp,
+        metadata: message.metadata,
+      }));
+
+      await Promise.all([
+        ThreadModel.updateOne({ threadId, userId }, { $set: {} }),
+        docs.length > 0 ? MessageModel.insertMany(docs, { ordered: false }) : Promise.resolve(),
+      ]);
     }, `addMessagesToThread(${userId}, ${threadId})`);
   };
 

--- a/packages/memory/mongodb/implements/thread.memory.ts
+++ b/packages/memory/mongodb/implements/thread.memory.ts
@@ -88,20 +88,25 @@ export class MongoDBThread implements IThreadMemory {
     messages: MessageObject[]
   ): Promise<void> {
     return this.executeWithRetry(async () => {
-      const docs = messages.map((message) => ({
-        threadId,
-        messageId: message.messageId,
-        userId,
-        role: message.role,
-        content: message.content,
-        timestamp: message.timestamp,
-        metadata: message.metadata,
-      }));
-
-      await Promise.all([
-        ThreadModel.updateOne({ threadId, userId }, { $set: {} }),
-        docs.length > 0 ? MessageModel.insertMany(docs, { ordered: false }) : Promise.resolve(),
-      ]);
+      if (messages.length > 0) {
+        const messageIds = messages.map((m) => m.messageId);
+        await MessageModel.deleteMany({ threadId, userId, messageId: { $in: messageIds } });
+        await MessageModel.insertMany(
+          messages.map((message) => ({
+            threadId,
+            messageId: message.messageId,
+            userId,
+            role: message.role,
+            content: message.content,
+            timestamp: message.timestamp,
+            metadata: message.metadata,
+          }))
+        );
+      }
+      await ThreadModel.updateOne(
+        { threadId, userId },
+        { $set: { updatedAt: new Date() } }
+      );
     }, `addMessagesToThread(${userId}, ${threadId})`);
   };
 

--- a/packages/memory/mongodb/models/messages.model.ts
+++ b/packages/memory/mongodb/models/messages.model.ts
@@ -52,6 +52,8 @@ export const MessageObjectSchema = new Schema(
 	},
 );
 
+MessageObjectSchema.index({ threadId: 1, messageId: 1 }, { unique: true });
+
 // Message Document interface
 export interface MessageDocument extends Document {
 	messageId: string;


### PR DESCRIPTION
## Summary

MongoDB 연결 풀 설정 최적화 및 `TooManyLogicalSessions` 에러 대응 로직을 추가합니다.

## Changes

### Connection Pool 설정 개선
- `maxPoolSize` 기본값을 `1` → `10`으로 상향
- `minPoolSize: 0`, `maxIdleTimeMS: 30000` 옵션 추가로 유휴 커넥션 자동 정리

### TooManyLogicalSessions 에러 핸들링
- `executeWithRetry`에서 에러 코드 `261` (`TooManyLogicalSessions`) 감지 시 disconnect → 재연결 → 재시도하는 복구 로직 추가

### addMessagesToThread 벌크 처리 개선
- 메시지를 개별 `create` 대신 `deleteMany` + `insertMany`로 변경하여 upsert 방식의 벌크 처리로 전환
- 불필요한 빈 `$set` 업데이트를 `updatedAt` 갱신으로 수정

### 기타
- `isConnected` → `connected` 프로퍼티 참조 수정 (6곳)
- `MessageObjectSchema`에 `{ threadId, messageId }` unique compound index 추가