### PR TITLE
Feature/seonghwa/template category

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "update:adk": "node scripts/update-adk.mjs"
   },
   "devDependencies": {
-    "@ainetwork/adk": "^0.6.2",
+    "@ainetwork/adk": "^0.6.3",
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
     "lerna": "^8.2.3",

--- a/packages/auth/firebase/package.json
+++ b/packages/auth/firebase/package.json
@@ -24,7 +24,7 @@
     "firebase-admin": "^12.0.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/google/package.json
+++ b/packages/auth/google/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/m365/package.json
+++ b/packages/auth/m365/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/next/package.json
+++ b/packages/auth/next/package.json
@@ -24,7 +24,7 @@
     "jsonwebtoken": "^9.0.2"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/memory/inmemory/package.json
+++ b/packages/memory/inmemory/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/mongodb/models/user-workflow.model.ts
+++ b/packages/memory/mongodb/models/user-workflow.model.ts
@@ -29,6 +29,9 @@ export const UserWorkflowObjectSchema = new Schema(
 			required: true,
 			default: false,
 		},
+		category: {
+			type: String,
+		},
 		templateId: {
 			type: String,
 		},
@@ -72,6 +75,7 @@ export interface UserWorkflowDocument extends Document {
 	title: string;
 	description?: string;
 	active: boolean;
+	category?: string;
 	templateId?: string;
 	content: string;
 	definition?: WorkflowDefinition;

--- a/packages/memory/mongodb/models/workflow-template.model.ts
+++ b/packages/memory/mongodb/models/workflow-template.model.ts
@@ -25,6 +25,9 @@ export const WorkflowTemplateObjectSchema = new Schema(
 			required: true,
 			default: false,
 		},
+		category: {
+			type: String,
+		},
 		content: {
 			type: String,
 			required: true,
@@ -46,6 +49,7 @@ export interface WorkflowTemplateDocument extends Document {
 	title: string;
 	description: string;
 	active: boolean;
+	category?: string;
 	content: string;
 	definition?: WorkflowDefinition;
 	variables?: Record<string, WorkflowVariable>;

--- a/packages/memory/mongodb/package.json
+++ b/packages/memory/mongodb/package.json
@@ -31,7 +31,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/azure/package.json
+++ b/packages/models/azure/package.json
@@ -24,7 +24,7 @@
     "openai": "^6.9.1"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/gemini/package.json
+++ b/packages/models/gemini/package.json
@@ -24,7 +24,7 @@
     "@google/genai": "^1.11.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.6.2"
+    "@ainetwork/adk": "^0.6.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     uuid "^11.1.0"
 
-"@ainetwork/adk@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@ainetwork/adk/-/adk-0.6.2.tgz#df551510f67b44565094c35b28412330775d5168"
-  integrity sha512-VlQz3GBg3w1Xfu9Eg6IXok9IexvuAYEhYAbwzmQ+kil+dRVUkkJSvY3mVka7RVkyNFIO70rAGH28PXV2IK49lw==
+"@ainetwork/adk@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@ainetwork/adk/-/adk-0.6.3.tgz#ef40f51351f3fb33001765d66ff0ae119bab3764"
+  integrity sha512-QobhB/JpNzIwGR56BubLVkeC07UH1GFOr8ffQm5wBhwbgHYdLIiHOx3UZBtE6yLpCkihLpqSJbQ2JNIVRiVLGA==
   dependencies:
     "@a2a-js/sdk" "^0.3.7"
     "@modelcontextprotocol/sdk" "^1.25.1"


### PR DESCRIPTION
## Summary

Adds support for the new `category` attribute on workflow templates and user workflows (introduced in `@ainetwork/adk` 0.6.3), and bumps the ADK dependency across all provider packages from `^0.6.2` to `^0.6.3`.

The `category` field is a UI-facing classification label for grouping workflows/templates (e.g. "식음", "객실"). For `UserWorkflow` it is copied from the source template.

## Changes

### `category` persistence (MongoDB provider)
Mongoose drops fields that aren't declared in the schema (strict mode is on by default), so without this change `category` would be **silently discarded** on `create()` and `$set` updates. Added the field to both schemas and their `Document` interfaces:

- `packages/memory/mongodb/models/workflow-template.model.ts` — added `category: { type: String }` to the schema and `category?: string` to `WorkflowTemplateDocument`
- `packages/memory/mongodb/models/user-workflow.model.ts` — same for the schema and `UserWorkflowDocument`

The `implements/*.memory.ts` mapping code needs no changes — it passes whole objects through `create()` / `lean()` / `$set`, so the field flows automatically once the schema allows it.

### No change required: in-memory provider
`packages/memory/inmemory` stores objects directly in a `Map` and spreads them on update (`{ ...existing, ...updates }`), so `category` is preserved without any schema change.

### Dependency bump
Bumped `@ainetwork/adk` from `^0.6.2` → `^0.6.3` in all provider packages (auth/firebase, auth/google, auth/m365, auth/next, memory/inmemory, memory/mongodb, models/azure, models/gemini) plus the root `package.json` and `yarn.lock`.

## Testing
- `tsc --noEmit` passes for the mongodb package

## Notes
- The `category` field is optional, so this is backward compatible — existing documents and callers that omit it are unaffected.