### PR TITLE
Feature/seonghwa/atomic document slot

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "update:adk": "node scripts/update-adk.mjs"
   },
   "devDependencies": {
-    "@ainetwork/adk": "^0.7.0",
+    "@ainetwork/adk": "^0.7.1",
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
     "lerna": "^8.2.3",

--- a/packages/auth/firebase/package.json
+++ b/packages/auth/firebase/package.json
@@ -24,7 +24,7 @@
     "firebase-admin": "^12.0.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/google/package.json
+++ b/packages/auth/google/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/m365/package.json
+++ b/packages/auth/m365/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/next/package.json
+++ b/packages/auth/next/package.json
@@ -24,7 +24,7 @@
     "jsonwebtoken": "^9.0.2"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/memory/inmemory/implements/document.memory.ts
+++ b/packages/memory/inmemory/implements/document.memory.ts
@@ -1,5 +1,9 @@
 import { IDocumentMemory } from "@ainetwork/adk/modules";
-import type { Document, DocumentFilter } from "@ainetwork/adk/types/document";
+import type {
+  Document,
+  DocumentFilter,
+  DocumentSlot,
+} from "@ainetwork/adk/types/document";
 
 export class InMemoryDocument implements IDocumentMemory {
   private documents: Map<string, Document> = new Map();
@@ -32,6 +36,42 @@ export class InMemoryDocument implements IDocumentMemory {
     // `documentId` is immutable; preserve it regardless of the payload.
     const updated = { ...existing, ...document, documentId };
     this.documents.set(documentId, updated);
+  }
+
+  public async updateDocumentSlot(
+    documentId: string,
+    slotId: string,
+    patch: Partial<DocumentSlot>
+  ): Promise<void> {
+    const existing = this.documents.get(documentId);
+    if (!existing) {
+      throw new Error(`Document not found: ${documentId}`);
+    }
+
+    // Read-modify-write on the latest stored document (not a caller snapshot),
+    // patching only the matched slot so concurrent fills of other slots are
+    // preserved. `undefined` patch values clear the corresponding key.
+    const { slotId: _slotId, ...fields } = patch;
+    const slots = (existing.slots ?? []).map((slot) => {
+      if (slot.slotId !== slotId) return slot;
+      const next: Record<string, unknown> = { ...slot };
+      for (const [key, value] of Object.entries(fields)) {
+        if (value === undefined) {
+          delete next[key];
+        } else {
+          next[key] = value;
+        }
+      }
+      return next as DocumentSlot;
+    });
+
+    this.documents.set(documentId, {
+      ...existing,
+      slots,
+      version: existing.version + 1,
+      updatedAt: new Date().toISOString(),
+      documentId,
+    });
   }
 
   public async deleteDocument(documentId: string): Promise<void> {

--- a/packages/memory/inmemory/package.json
+++ b/packages/memory/inmemory/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/inmemory/tests/document-slot-concurrency.test.ts
+++ b/packages/memory/inmemory/tests/document-slot-concurrency.test.ts
@@ -1,0 +1,83 @@
+import type { Document } from "@ainetwork/adk/types/document";
+import { InMemoryDocument } from "../implements/document.memory";
+
+function makeDoc(): Document {
+  return {
+    documentId: "doc-1",
+    userId: "user-1",
+    title: "Log book",
+    format: "MARKDOWN",
+    content: "{{slot:a}}{{slot:b}}",
+    source: "MANUAL",
+    version: 1,
+    createdAt: "2026-06-25T00:00:00.000Z",
+    updatedAt: "2026-06-25T00:00:00.000Z",
+    slots: [
+      { slotId: "a", status: "empty" },
+      { slotId: "b", status: "empty" },
+    ],
+  };
+}
+
+describe("InMemoryDocument.updateDocumentSlot — concurrent fills", () => {
+  it("patches only the target slot and preserves a sibling slot's fragment", async () => {
+    const memory = new InMemoryDocument();
+    await memory.createDocument(makeDoc());
+
+    // Slot A finishes first and is resolved with a fragment.
+    await memory.updateDocumentSlot("doc-1", "a", {
+      status: "resolved",
+      fragment: {
+        content: "A result",
+        source: { type: "WORKFLOW", workflowId: "wf-a" },
+        resolvedAt: "2026-06-25T00:00:01.000Z",
+      },
+    });
+
+    // Slot B finishes later. This used to clobber A when the whole slots array
+    // was rewritten from a stale snapshot taken before A resolved.
+    await memory.updateDocumentSlot("doc-1", "b", {
+      status: "resolved",
+      fragment: {
+        content: "B result",
+        source: { type: "WORKFLOW", workflowId: "wf-b" },
+        resolvedAt: "2026-06-25T00:00:02.000Z",
+      },
+    });
+
+    const doc = await memory.getDocument("doc-1");
+    const a = doc?.slots?.find((s) => s.slotId === "a");
+    const b = doc?.slots?.find((s) => s.slotId === "b");
+
+    expect(a?.status).toBe("resolved");
+    expect(a?.fragment?.content).toBe("A result");
+    expect(b?.status).toBe("resolved");
+    expect(b?.fragment?.content).toBe("B result");
+  });
+
+  it("clears keys whose patch value is undefined", async () => {
+    const memory = new InMemoryDocument();
+    const doc = makeDoc();
+    doc.slots = [{ slotId: "a", status: "failed", error: "boom" }];
+    await memory.createDocument(doc);
+
+    await memory.updateDocumentSlot("doc-1", "a", {
+      status: "running",
+      error: undefined,
+    });
+
+    const a = (await memory.getDocument("doc-1"))?.slots?.find((s) => s.slotId === "a");
+    expect(a?.status).toBe("running");
+    expect("error" in (a ?? {})).toBe(false);
+  });
+
+  it("bumps version on each slot update", async () => {
+    const memory = new InMemoryDocument();
+    await memory.createDocument(makeDoc());
+
+    await memory.updateDocumentSlot("doc-1", "a", { status: "running" });
+    await memory.updateDocumentSlot("doc-1", "b", { status: "running" });
+
+    expect((await memory.getDocument("doc-1"))?.version).toBe(3);
+  });
+});

--- a/packages/memory/mongodb/implements/document.memory.ts
+++ b/packages/memory/mongodb/implements/document.memory.ts
@@ -1,5 +1,9 @@
 import type { IDocumentMemory } from "@ainetwork/adk/modules";
-import type { Document, DocumentFilter } from "@ainetwork/adk/types/document";
+import type {
+  Document,
+  DocumentFilter,
+  DocumentSlot,
+} from "@ainetwork/adk/types/document";
 import { DocumentModel } from "../models/document.model";
 
 export type ExecuteWithRetryFn = <T>(
@@ -52,6 +56,39 @@ export class MongoDBDocument implements IDocumentMemory {
         { $set: mutableUpdates }
       ).maxTimeMS(timeout);
     }, "updateDocument()");
+  }
+
+  public async updateDocumentSlot(
+    documentId: string,
+    slotId: string,
+    patch: Partial<DocumentSlot>
+  ): Promise<void> {
+    // Target only the matched slot via the positional `$` operator so
+    // concurrent fills of other slots are never overwritten. `slotId` is the
+    // slot's identity and must not be patched.
+    const { slotId: _slotId, ...fields } = patch;
+    const set: Record<string, unknown> = { updatedAt: new Date().toISOString() };
+    const unset: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(fields)) {
+      if (value === undefined) {
+        unset[`slots.$.${key}`] = "";
+      } else {
+        set[`slots.$.${key}`] = value;
+      }
+    }
+
+    const update: Record<string, unknown> = { $set: set, $inc: { version: 1 } };
+    if (Object.keys(unset).length > 0) {
+      update.$unset = unset;
+    }
+
+    return this.executeWithRetry(async () => {
+      const timeout = this.getOperationTimeout();
+      await DocumentModel.updateOne(
+        { documentId, "slots.slotId": slotId },
+        update
+      ).maxTimeMS(timeout);
+    }, "updateDocumentSlot()");
   }
 
   public async deleteDocument(documentId: string): Promise<void> {

--- a/packages/memory/mongodb/package.json
+++ b/packages/memory/mongodb/package.json
@@ -31,7 +31,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/azure/package.json
+++ b/packages/models/azure/package.json
@@ -24,7 +24,7 @@
     "openai": "^6.9.1"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/gemini/package.json
+++ b/packages/models/gemini/package.json
@@ -24,7 +24,7 @@
     "@google/genai": "^1.11.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.7.0"
+    "@ainetwork/adk": "^0.7.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     uuid "^11.1.0"
 
-"@ainetwork/adk@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@ainetwork/adk/-/adk-0.7.0.tgz#4f02ed5b8730b8b4b3c786ad9a84702b392a3ecf"
-  integrity sha512-u9eeqp0G+sWtyRzqb9yB/gcbEvmqqtO7wgO3gQ4/X1mvmh5zyV9ZWuPNEqxCe7bo7EsiuNIeygiL4FcGD/xQpA==
+"@ainetwork/adk@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@ainetwork/adk/-/adk-0.7.1.tgz#1b92b4f675b4448584f0c83287484f3c8cd2967d"
+  integrity sha512-TYrVy1FZeDsuYrHdJxe8fhNm96vFIxCWMW05ukGKdWKQRqmM0czGR4GyOX6lMfqReHWu6h9rA/cNIsKqswTrtA==
   dependencies:
     "@a2a-js/sdk" "^0.3.7"
     "@modelcontextprotocol/sdk" "^1.25.1"


### PR DESCRIPTION
## Summary

Adds an atomic, slot-scoped update path to the document memory providers so that concurrent slot fills no longer clobber each other, and bumps the `@ainetwork/adk` dependency to `^0.7.1` across all packages.

## Motivation

The existing `updateDocument()` path rewrites a document from a caller-supplied snapshot. When two slots of the same document are filled concurrently (e.g. parallel workflows resolving different `{{slot:*}}` fragments), the later write replaces the entire `slots` array from a snapshot taken *before* the earlier write landed — silently discarding the first slot's result.

This PR introduces `updateDocumentSlot(documentId, slotId, patch)` that patches **only the matched slot**, leaving sibling slots untouched.

## Changes

### `@ainetwork/adk-provider-memory-inmemory`
- New `updateDocumentSlot()` doing a read-modify-write against the latest stored document (not a caller snapshot), patching only the slot whose `slotId` matches.
- `undefined` patch values delete the corresponding key; `slotId` itself is treated as identity and is never patched.
- Bumps `version` and refreshes `updatedAt` on each call.

### `@ainetwork/adk-provider-memory-mongodb`
- New `updateDocumentSlot()` using the positional `$` operator (`{ documentId, "slots.slotId": slotId }`) so the update targets a single array element.
- Builds `$set` / `$unset` from the patch (`undefined` → `$unset`), with `$inc: { version: 1 }` and an `updatedAt` refresh, wrapped in the existing `executeWithRetry` + operation-timeout machinery.
