### PR TITLE
Feat/intent workflow mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "update:adk": "node scripts/update-adk.mjs"
   },
   "devDependencies": {
-    "@ainetwork/adk": "^0.8.0",
+    "@ainetwork/adk": "^0.8.1",
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
     "lerna": "^8.2.3",

--- a/packages/auth/firebase/package.json
+++ b/packages/auth/firebase/package.json
@@ -24,7 +24,7 @@
     "firebase-admin": "^12.0.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/google/package.json
+++ b/packages/auth/google/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/m365/package.json
+++ b/packages/auth/m365/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/next/package.json
+++ b/packages/auth/next/package.json
@@ -24,7 +24,7 @@
     "jsonwebtoken": "^9.0.2"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/authz/mongodb/package.json
+++ b/packages/authz/mongodb/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/inmemory/package.json
+++ b/packages/memory/inmemory/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/mongodb/models/intent.model.ts
+++ b/packages/memory/mongodb/models/intent.model.ts
@@ -39,6 +39,10 @@ const IntentObjectSchema = new Schema(
 			enum: ["auto", "required"],
 			required: false,
 		},
+		workflowId: {
+			type: String,
+			required: false,
+		},
 	},
 );
 

--- a/packages/memory/mongodb/package.json
+++ b/packages/memory/mongodb/package.json
@@ -31,7 +31,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/azure/package.json
+++ b/packages/models/azure/package.json
@@ -24,7 +24,7 @@
     "openai": "^6.9.1"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/gemini/package.json
+++ b/packages/models/gemini/package.json
@@ -24,7 +24,7 @@
     "@google/genai": "^1.11.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.0"
+    "@ainetwork/adk": "^0.8.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
## Intent.workflowId를 mongodb 인텐트 스키마에 영속화

ADK의 intent→workflow 매핑 기능(짝 PR: ain-adk-v0 `feat/intent-workflow-mapping`)을 위한
스키마 필드 추가입니다.

### 변경 사항

- `packages/memory/mongodb/models/intent.model.ts`의 `IntentObjectSchema`에
  `workflowId: { type: String, required: false }` 추가 (4줄)

### 왜 필수인가

mongoose strict mode는 스키마에 없는 필드를 **저장 시 버리고 조회 시에도 노출하지 않습니다.**
이 필드 없이는 `listIntents()`가 `workflowId`를 절대 반환하지 않아 ADK의 런타임 분기가
조용히 죽습니다. `IntentDocument` 인터페이스는 `Omit<Intent, 'id'>` 파생이라 별도 수정 불필요.

### 하위호환 / 마이그레이션

- optional 필드라 마이그레이션 불필요 — 기존 문서는 필드 없음 → prompt 경로 그대로
- **ADK 새 빌드와 함께 배포 필수** (짝 PR 참조)