### PR TITLE
feat(memory): 문서/워크플로우 목록 페이지네이션 구현 — $or union 쿼리, summary projection

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "update:adk": "node scripts/update-adk.mjs"
   },
   "devDependencies": {
-    "@ainetwork/adk": "^0.8.2",
+    "@ainetwork/adk": "^0.8.3",
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
     "lerna": "^8.2.3",

--- a/packages/auth/firebase/package.json
+++ b/packages/auth/firebase/package.json
@@ -24,7 +24,7 @@
     "firebase-admin": "^12.0.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/google/package.json
+++ b/packages/auth/google/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/m365/package.json
+++ b/packages/auth/m365/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/next/package.json
+++ b/packages/auth/next/package.json
@@ -24,7 +24,7 @@
     "jsonwebtoken": "^9.0.2"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/authz/mongodb/package.json
+++ b/packages/authz/mongodb/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/inmemory/implements/document.memory.ts
+++ b/packages/memory/inmemory/implements/document.memory.ts
@@ -148,7 +148,7 @@ export class InMemoryDocument implements IDocumentMemory {
 			}
 		}
 		let items = [...byId.values()].sort((a, b) =>
-			b.updatedAt.localeCompare(a.updatedAt),
+			String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")),
 		);
 		if (options?.limit !== undefined || options?.offset) {
 			const start = options?.offset ?? 0;

--- a/packages/memory/inmemory/implements/document.memory.ts
+++ b/packages/memory/inmemory/implements/document.memory.ts
@@ -147,8 +147,10 @@ export class InMemoryDocument implements IDocumentMemory {
 				byId.set(d.documentId, d);
 			}
 		}
-		let items = [...byId.values()].sort((a, b) =>
-			String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")),
+		let items = [...byId.values()].sort(
+			(a, b) =>
+				String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")) ||
+				b.documentId.localeCompare(a.documentId),
 		);
 		if (options?.limit !== undefined || options?.offset) {
 			const start = options?.offset ?? 0;

--- a/packages/memory/inmemory/implements/document.memory.ts
+++ b/packages/memory/inmemory/implements/document.memory.ts
@@ -2,6 +2,8 @@ import type { IDocumentMemory } from "@ainetwork/adk/modules";
 import type {
 	Document,
 	DocumentFilter,
+	DocumentFilterSet,
+	DocumentListOptions,
 	DocumentSlot,
 } from "@ainetwork/adk/types/document";
 
@@ -122,7 +124,54 @@ export class InMemoryDocument implements IDocumentMemory {
 				}),
 			);
 		}
+		if (filter?.dateFrom || filter?.dateTo) {
+			documents = documents.filter((d) => {
+				const date = d.labels?.date;
+				if (!date) return false;
+				if (filter.dateFrom && date < filter.dateFrom) return false;
+				if (filter.dateTo && date > filter.dateTo) return false;
+				return true;
+			});
+		}
 
 		return documents;
+	}
+
+	public async listDocumentsAny(
+		filters: DocumentFilterSet[],
+		options?: DocumentListOptions,
+	): Promise<Document[]> {
+		const byId = new Map<string, Document>();
+		for (const set of filters) {
+			for (const d of await this.listDocuments(set.userId, set.filter)) {
+				byId.set(d.documentId, d);
+			}
+		}
+		let items = [...byId.values()].sort((a, b) =>
+			b.updatedAt.localeCompare(a.updatedAt),
+		);
+		if (options?.limit !== undefined || options?.offset) {
+			const start = options?.offset ?? 0;
+			items = items.slice(
+				start,
+				options?.limit !== undefined ? start + options.limit : undefined,
+			);
+		}
+		if (options?.summary) {
+			items = items.map(({ slots: _slots, ...rest }) => rest as Document);
+		}
+		return items;
+	}
+
+	public async countDocumentsAny(
+		filters: DocumentFilterSet[],
+	): Promise<number> {
+		const ids = new Set<string>();
+		for (const set of filters) {
+			for (const d of await this.listDocuments(set.userId, set.filter)) {
+				ids.add(d.documentId);
+			}
+		}
+		return ids.size;
 	}
 }

--- a/packages/memory/inmemory/implements/user-workflow.memory.ts
+++ b/packages/memory/inmemory/implements/user-workflow.memory.ts
@@ -1,4 +1,5 @@
 import type { IUserWorkflowMemory } from "@ainetwork/adk/modules";
+import type { ListOptions } from "@ainetwork/adk/types/list";
 import type { UserWorkflow } from "@ainetwork/adk/types/memory";
 
 export class InMemoryUserWorkflow implements IUserWorkflowMemory {
@@ -56,21 +57,41 @@ export class InMemoryUserWorkflow implements IUserWorkflowMemory {
 		}
 	}
 
-	public async listUserWorkflows(userId?: string): Promise<UserWorkflow[]> {
+	public async listUserWorkflows(
+		userId?: string,
+		options?: ListOptions,
+	): Promise<UserWorkflow[]> {
+		let workflows: UserWorkflow[];
 		if (userId) {
 			const userWorkflowIds = this.userWorkflowIndex.get(userId);
 			if (!userWorkflowIds) return [];
-			const workflows: UserWorkflow[] = [];
+			workflows = [];
 			for (const workflowId of userWorkflowIds) {
 				const workflow = this.workflows.get(workflowId);
 				if (workflow) {
 					workflows.push(workflow);
 				}
 			}
-			return workflows;
+		} else {
+			workflows = Array.from(this.workflows.values());
 		}
 
-		return Array.from(this.workflows.values());
+		if (options?.limit !== undefined || options?.offset) {
+			workflows = [...workflows].sort((a, b) =>
+				(b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
+			);
+			const start = options.offset ?? 0;
+			workflows = workflows.slice(
+				start,
+				options.limit !== undefined ? start + options.limit : undefined,
+			);
+		}
+		return workflows;
+	}
+
+	public async countUserWorkflows(userId?: string): Promise<number> {
+		if (!userId) return this.workflows.size;
+		return (await this.listUserWorkflows(userId)).length;
 	}
 
 	public async listActiveScheduledWorkflows(): Promise<UserWorkflow[]> {

--- a/packages/memory/inmemory/implements/user-workflow.memory.ts
+++ b/packages/memory/inmemory/implements/user-workflow.memory.ts
@@ -77,6 +77,10 @@ export class InMemoryUserWorkflow implements IUserWorkflowMemory {
 		}
 
 		if (options?.limit !== undefined || options?.offset) {
+			// In-memory-created workflows typically have no updatedAt (only the
+			// mongodb provider stamps it via mongoose `timestamps: true`), so this
+			// sort degrades to insertion order for this provider — acceptable for
+			// a dev/testing provider.
 			workflows = [...workflows].sort((a, b) =>
 				(b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
 			);

--- a/packages/memory/inmemory/implements/user-workflow.memory.ts
+++ b/packages/memory/inmemory/implements/user-workflow.memory.ts
@@ -81,8 +81,10 @@ export class InMemoryUserWorkflow implements IUserWorkflowMemory {
 			// mongodb provider stamps it via mongoose `timestamps: true`), so this
 			// sort degrades to insertion order for this provider — acceptable for
 			// a dev/testing provider.
-			workflows = [...workflows].sort((a, b) =>
-				(b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
+			workflows = [...workflows].sort(
+				(a, b) =>
+					String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")) ||
+					b.workflowId.localeCompare(a.workflowId),
 			);
 			const start = options.offset ?? 0;
 			workflows = workflows.slice(

--- a/packages/memory/inmemory/package.json
+++ b/packages/memory/inmemory/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/inmemory/tests/document-list-pagination.test.ts
+++ b/packages/memory/inmemory/tests/document-list-pagination.test.ts
@@ -1,0 +1,91 @@
+import type { Document } from "@ainetwork/adk/types/document";
+import { InMemoryDocument } from "../implements/document.memory";
+
+function doc(
+	id: string,
+	userId: string,
+	over: Partial<Document> = {},
+): Document {
+	return {
+		documentId: id,
+		userId,
+		title: id,
+		format: "MARKDOWN",
+		content: "x",
+		source: "MANUAL",
+		version: 1,
+		createdAt: "t",
+		updatedAt: "2026-08-01T00:00:00.000Z",
+		slots: [{ slotId: "s1", status: "empty" }],
+		...over,
+	};
+}
+
+async function seed(): Promise<InMemoryDocument> {
+	const m = new InMemoryDocument();
+	// A: u1 소유, 8/1. B: u2 소유 + seoul, 8/3. C: u1 소유 + seoul, 8/2.
+	await m.createDocument(doc("A", "u1"));
+	await m.createDocument(
+		doc("B", "u2", {
+			updatedAt: "2026-08-03T00:00:00.000Z",
+			labels: { workplace: "seoul", date: "2026-08-03" },
+		}),
+	);
+	await m.createDocument(
+		doc("C", "u1", {
+			updatedAt: "2026-08-02T00:00:00.000Z",
+			labels: { workplace: "seoul", date: "2026-07-15" },
+		}),
+	);
+	return m;
+}
+
+describe("InMemoryDocument date range + listDocumentsAny", () => {
+	it("filters by labels.date range; documents without the label are excluded", async () => {
+		const m = await seed();
+		const out = await m.listDocuments(undefined, {
+			dateFrom: "2026-08-01",
+			dateTo: "2026-08-31",
+		});
+		expect(out.map((d) => d.documentId)).toEqual(["B"]);
+	});
+
+	it("unions filter sets, dedupes by documentId, sorts updatedAt desc", async () => {
+		const m = await seed();
+		// C는 두 집합(u1 소유, seoul) 모두에 걸리지만 한 번만 나와야 한다
+		const items = await m.listDocumentsAny([
+			{ userId: "u1" },
+			{ filter: { labels: { workplace: "seoul" } } },
+		]);
+		expect(items.map((d) => d.documentId)).toEqual(["B", "C", "A"]);
+	});
+
+	it("applies offset/limit after sorting", async () => {
+		const m = await seed();
+		const items = await m.listDocumentsAny(
+			[{ userId: "u1" }, { filter: { labels: { workplace: "seoul" } } }],
+			{ limit: 1, offset: 1 },
+		);
+		expect(items.map((d) => d.documentId)).toEqual(["C"]);
+	});
+
+	it("summary omits slots via a copy, leaving stored documents intact", async () => {
+		const m = await seed();
+		const items = await m.listDocumentsAny([{ userId: "u1" }], {
+			summary: true,
+		});
+		expect(items[0]).not.toHaveProperty("slots");
+		const stored = await m.getDocument("A");
+		expect(stored?.slots).toBeDefined();
+	});
+
+	it("countDocumentsAny counts the deduped union", async () => {
+		const m = await seed();
+		await expect(
+			m.countDocumentsAny([
+				{ userId: "u1" },
+				{ filter: { labels: { workplace: "seoul" } } },
+			]),
+		).resolves.toBe(3);
+	});
+});

--- a/packages/memory/inmemory/tests/user-workflow-pagination.test.ts
+++ b/packages/memory/inmemory/tests/user-workflow-pagination.test.ts
@@ -1,0 +1,25 @@
+import type { UserWorkflow } from "@ainetwork/adk/types/memory";
+import { InMemoryUserWorkflow } from "../implements/user-workflow.memory";
+
+function wf(id: string, updatedAt: string): UserWorkflow {
+	return { workflowId: id, userId: "u1", updatedAt } as UserWorkflow;
+}
+
+describe("InMemoryUserWorkflow pagination", () => {
+	it("sorts updatedAt desc and slices when options given; count reports all", async () => {
+		const m = new InMemoryUserWorkflow();
+		await m.createUserWorkflow(wf("old", "2026-08-01"));
+		await m.createUserWorkflow(wf("new", "2026-08-03"));
+		await m.createUserWorkflow(wf("mid", "2026-08-02"));
+
+		const items = await m.listUserWorkflows("u1", { limit: 2, offset: 0 });
+		expect(items.map((w) => w.workflowId)).toEqual(["new", "mid"]);
+		await expect(m.countUserWorkflows("u1")).resolves.toBe(3);
+	});
+
+	it("without options returns everything unchanged (legacy behavior)", async () => {
+		const m = new InMemoryUserWorkflow();
+		await m.createUserWorkflow(wf("a", "2026-08-01"));
+		await expect(m.listUserWorkflows("u1")).resolves.toHaveLength(1);
+	});
+});

--- a/packages/memory/mongodb/implements/build-document-query.ts
+++ b/packages/memory/mongodb/implements/build-document-query.ts
@@ -1,10 +1,16 @@
-import type { DocumentFilter } from "@ainetwork/adk/types/document";
+import type {
+	DocumentFilter,
+	DocumentFilterSet,
+} from "@ainetwork/adk/types/document";
 
 /** Keys containing `$` or `.` could smuggle Mongo operators or path
  * traversal into the query, so they are skipped entirely. */
 function isSafeLabelKey(key: string): boolean {
 	return !key.includes("$") && !key.includes(".");
 }
+
+/** YYYY-MM-DD only — anything else (operators, other shapes) is dropped. */
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /** Builds the Mongo query object for listDocuments. Scalar label values match
  * exactly; array values use $in.
@@ -43,5 +49,32 @@ export function buildDocumentQuery(
 			// Any other shape (operator objects, numbers, ...) is dropped.
 		}
 	}
+	// Inclusive range over labels.date. Applied after the labels loop so a
+	// range always wins over an exact labels.date value from the same query.
+	const range: Record<string, string> = {};
+	if (typeof filter?.dateFrom === "string" && DATE_RE.test(filter.dateFrom)) {
+		range.$gte = filter.dateFrom;
+	}
+	if (typeof filter?.dateTo === "string" && DATE_RE.test(filter.dateTo)) {
+		range.$lte = filter.dateTo;
+	}
+	if (Object.keys(range).length > 0) {
+		query["labels.date"] = range;
+	}
 	return query;
+}
+
+/**
+ * Union (OR) of filter sets as one Mongo query, so skip/limit/count stay
+ * correct across RBAC scopes. Callers guarantee at least one set — an empty
+ * union would silently mean "match everything", so fail loudly instead.
+ */
+export function buildDocumentOrQuery(
+	filters: DocumentFilterSet[],
+): Record<string, unknown> {
+	if (filters.length === 0) {
+		throw new Error("buildDocumentOrQuery: empty filter sets");
+	}
+	const clauses = filters.map((s) => buildDocumentQuery(s.userId, s.filter));
+	return clauses.length === 1 ? clauses[0] : { $or: clauses };
 }

--- a/packages/memory/mongodb/implements/document.memory.ts
+++ b/packages/memory/mongodb/implements/document.memory.ts
@@ -2,10 +2,12 @@ import type { IDocumentMemory } from "@ainetwork/adk/modules";
 import type {
 	Document,
 	DocumentFilter,
+	DocumentFilterSet,
+	DocumentListOptions,
 	DocumentSlot,
 } from "@ainetwork/adk/types/document";
 import { DocumentModel } from "../models/document.model";
-import { buildDocumentQuery } from "./build-document-query";
+import { buildDocumentOrQuery, buildDocumentQuery } from "./build-document-query";
 
 export type ExecuteWithRetryFn = <T>(
 	operation: () => Promise<T>,
@@ -120,6 +122,39 @@ export class MongoDBDocument implements IDocumentMemory {
 				.lean<Document[]>();
 			return documents;
 		}, "listDocuments()");
+	}
+
+	public async listDocumentsAny(
+		filters: DocumentFilterSet[],
+		options?: DocumentListOptions,
+	): Promise<Document[]> {
+		return this.executeWithRetry(async () => {
+			const timeout = this.getOperationTimeout();
+			let query = DocumentModel.find(buildDocumentOrQuery(filters))
+				.sort({ updatedAt: -1 })
+				.maxTimeMS(timeout);
+			if (options?.summary) {
+				query = query.select("-slots");
+			}
+			if (options?.offset) {
+				query = query.skip(options.offset);
+			}
+			if (options?.limit !== undefined) {
+				query = query.limit(options.limit);
+			}
+			return await query.lean<Document[]>();
+		}, "listDocumentsAny()");
+	}
+
+	public async countDocumentsAny(
+		filters: DocumentFilterSet[],
+	): Promise<number> {
+		return this.executeWithRetry(async () => {
+			const timeout = this.getOperationTimeout();
+			return await DocumentModel.countDocuments(
+				buildDocumentOrQuery(filters),
+			).maxTimeMS(timeout);
+		}, "countDocumentsAny()");
 	}
 
 	public async listAutoRefreshPendingDocuments(): Promise<Document[]> {

--- a/packages/memory/mongodb/implements/document.memory.ts
+++ b/packages/memory/mongodb/implements/document.memory.ts
@@ -130,17 +130,17 @@ export class MongoDBDocument implements IDocumentMemory {
 	): Promise<Document[]> {
 		return this.executeWithRetry(async () => {
 			const timeout = this.getOperationTimeout();
-			let query = DocumentModel.find(buildDocumentOrQuery(filters))
+			const query = DocumentModel.find(buildDocumentOrQuery(filters))
 				.sort({ updatedAt: -1 })
 				.maxTimeMS(timeout);
 			if (options?.summary) {
-				query = query.select("-slots");
+				query.select("-slots");
 			}
 			if (options?.offset) {
-				query = query.skip(options.offset);
+				query.skip(options.offset);
 			}
 			if (options?.limit !== undefined) {
-				query = query.limit(options.limit);
+				query.limit(options.limit);
 			}
 			return await query.lean<Document[]>();
 		}, "listDocumentsAny()");

--- a/packages/memory/mongodb/implements/document.memory.ts
+++ b/packages/memory/mongodb/implements/document.memory.ts
@@ -130,8 +130,11 @@ export class MongoDBDocument implements IDocumentMemory {
 	): Promise<Document[]> {
 		return this.executeWithRetry(async () => {
 			const timeout = this.getOperationTimeout();
+			// documentId tiebreaker: equal updatedAt values (bulk workflow runs)
+			// must order identically across per-page queries, or documents can
+			// appear on two pages or on none.
 			const query = DocumentModel.find(buildDocumentOrQuery(filters))
-				.sort({ updatedAt: -1 })
+				.sort({ updatedAt: -1, documentId: -1 })
 				.maxTimeMS(timeout);
 			if (options?.summary) {
 				query.select("-slots");

--- a/packages/memory/mongodb/implements/user-workflow.memory.ts
+++ b/packages/memory/mongodb/implements/user-workflow.memory.ts
@@ -86,7 +86,7 @@ export class MongoDBUserWorkflow implements IUserWorkflowMemory {
 			const filter = userId ? { userId } : {};
 			let query = UserWorkflowModel.find(filter).maxTimeMS(timeout);
 			if (options?.limit !== undefined || options?.offset) {
-				query = query.sort({ updatedAt: -1 });
+				query = query.sort({ updatedAt: -1, workflowId: -1 });
 				if (options.offset) {
 					query = query.skip(options.offset);
 				}

--- a/packages/memory/mongodb/implements/user-workflow.memory.ts
+++ b/packages/memory/mongodb/implements/user-workflow.memory.ts
@@ -1,4 +1,5 @@
 import type { IUserWorkflowMemory } from "@ainetwork/adk/modules";
+import type { ListOptions } from "@ainetwork/adk/types/list";
 import type { UserWorkflow } from "@ainetwork/adk/types/memory";
 import { UserWorkflowModel } from "../models/user-workflow.model";
 
@@ -76,15 +77,33 @@ export class MongoDBUserWorkflow implements IUserWorkflowMemory {
 		}, "deleteUserWorkflow()");
 	}
 
-	public async listUserWorkflows(userId?: string): Promise<UserWorkflow[]> {
+	public async listUserWorkflows(
+		userId?: string,
+		options?: ListOptions,
+	): Promise<UserWorkflow[]> {
 		return this.executeWithRetry(async () => {
 			const timeout = this.getOperationTimeout();
-			const query = userId ? { userId } : {};
-			const workflows = await UserWorkflowModel.find(query)
-				.maxTimeMS(timeout)
-				.lean<UserWorkflow[]>();
-			return workflows;
+			const filter = userId ? { userId } : {};
+			let query = UserWorkflowModel.find(filter).maxTimeMS(timeout);
+			if (options?.limit !== undefined || options?.offset) {
+				query = query.sort({ updatedAt: -1 });
+				if (options.offset) {
+					query = query.skip(options.offset);
+				}
+				if (options.limit !== undefined) {
+					query = query.limit(options.limit);
+				}
+			}
+			return await query.lean<UserWorkflow[]>();
 		}, "listUserWorkflows()");
+	}
+
+	public async countUserWorkflows(userId?: string): Promise<number> {
+		return this.executeWithRetry(async () => {
+			const timeout = this.getOperationTimeout();
+			const filter = userId ? { userId } : {};
+			return await UserWorkflowModel.countDocuments(filter).maxTimeMS(timeout);
+		}, "countUserWorkflows()");
 	}
 
 	public async listActiveScheduledWorkflows(): Promise<UserWorkflow[]> {

--- a/packages/memory/mongodb/package.json
+++ b/packages/memory/mongodb/package.json
@@ -31,7 +31,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/mongodb/tests/build-document-query.test.ts
+++ b/packages/memory/mongodb/tests/build-document-query.test.ts
@@ -1,4 +1,7 @@
-import { buildDocumentQuery, buildDocumentOrQuery } from "../implements/build-document-query";
+import {
+	buildDocumentOrQuery,
+	buildDocumentQuery,
+} from "../implements/build-document-query";
 
 describe("buildDocumentQuery", () => {
 	it("adds userId and scalar fields", () => {

--- a/packages/memory/mongodb/tests/build-document-query.test.ts
+++ b/packages/memory/mongodb/tests/build-document-query.test.ts
@@ -1,4 +1,4 @@
-import { buildDocumentQuery } from "../implements/build-document-query";
+import { buildDocumentQuery, buildDocumentOrQuery } from "../implements/build-document-query";
 
 describe("buildDocumentQuery", () => {
 	it("adds userId and scalar fields", () => {
@@ -70,5 +70,63 @@ describe("buildDocumentQuery", () => {
 			});
 			expect(q).toEqual({});
 		});
+	});
+});
+
+describe("date range", () => {
+	it("builds labels.date range from dateFrom/dateTo", () => {
+		const q = buildDocumentQuery(undefined, {
+			dateFrom: "2026-08-01",
+			dateTo: "2026-08-31",
+		});
+		expect(q).toEqual({
+			"labels.date": { $gte: "2026-08-01", $lte: "2026-08-31" },
+		});
+	});
+
+	it("drops malformed date bounds independently", () => {
+		const q = buildDocumentQuery(undefined, {
+			dateFrom: "20260801",
+			dateTo: "2026-08-31",
+		});
+		expect(q).toEqual({ "labels.date": { $lte: "2026-08-31" } });
+	});
+
+	it("drops operator smuggling in date bounds", () => {
+		const q = buildDocumentQuery(undefined, {
+			dateFrom: { $ne: "x" } as never,
+		});
+		expect(q).toEqual({});
+	});
+
+	it("date range wins over an exact labels.date filter", () => {
+		const q = buildDocumentQuery(undefined, {
+			labels: { date: "2026-08-15" },
+			dateFrom: "2026-08-01",
+		});
+		expect(q).toEqual({ "labels.date": { $gte: "2026-08-01" } });
+	});
+});
+
+describe("buildDocumentOrQuery", () => {
+	it("single set → plain query (no $or)", () => {
+		const q = buildDocumentOrQuery([
+			{ userId: "u1", filter: { source: "MANUAL" as never } },
+		]);
+		expect(q).toEqual({ userId: "u1", source: "MANUAL" });
+	});
+
+	it("multiple sets → $or of per-set queries", () => {
+		const q = buildDocumentOrQuery([
+			{ userId: "u1", filter: {} },
+			{ filter: { labels: { workplace: "seoul" } } },
+		]);
+		expect(q).toEqual({
+			$or: [{ userId: "u1" }, { "labels.workplace": "seoul" }],
+		});
+	});
+
+	it("throws on empty filter sets", () => {
+		expect(() => buildDocumentOrQuery([])).toThrow();
 	});
 });

--- a/packages/models/azure/package.json
+++ b/packages/models/azure/package.json
@@ -24,7 +24,7 @@
     "openai": "^6.9.1"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/gemini/package.json
+++ b/packages/models/gemini/package.json
@@ -24,7 +24,7 @@
     "@google/genai": "^1.11.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.2"
+    "@ainetwork/adk": "^0.8.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
## 개요

ain-adk `feat/list-pagination`(목록 API 페이지네이션)의 provider 구현입니다. **해당 ADK PR과 동시 배포해야 합니다.**

## 변경 사항

**memory/mongodb**
- `buildDocumentQuery`: `dateFrom`/`dateTo` → `labels.date` 범위 (`^\d{4}-\d{2}-\d{2}$` 검증, 연산자 스머글링 드롭 — 기존 라벨 방어 원칙 동일)
- `buildDocumentOrQuery(filterSets)`: RBAC 스코프 union을 단일 `$or` 쿼리로 — DB 레벨 skip/limit/count 정합성 확보. 빈 집합은 throw(전체 매치 방지)
- `listDocumentsAny`/`countDocumentsAny`: `sort({updatedAt: -1, documentId: -1})`(tiebreaker로 페이지 경계 안정), `summary`면 `-slots` projection, skip/limit
- `listUserWorkflows(options)`/`countUserWorkflows`: options 없으면 기존 동작 그대로(레거시 무영향)

**memory/inmemory**
- 동등 시맨틱 구현: union dedupe, 정렬+tiebreaker, `summary`는 shallow copy로 slots 제거(저장 객체 불변), Date-safe comparator

## 테스트

- `pnpm test` 170/170 (신규: 쿼리 빌더 date-range/$or/인젝션, inmemory union/slice/summary/count)

## 배포 주의

- **ADK와 동시 배포.** 퍼블리시 시 `@ainetwork/adk` peerDependencies를 신규 ADK 버전 이상으로 범프 필요 — 새 provider 타입이 ADK의 `types/list` 등 신 타입을 import하므로, 구 ADK 조합에서는 타입체크가 깨집니다 (런타임은 타입 전용 import라 안전).