### PR TITLE
Fix/model history object content

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "update:adk": "node scripts/update-adk.mjs"
   },
   "devDependencies": {
-    "@ainetwork/adk": "^0.8.4",
+    "@ainetwork/adk": "^0.8.5",
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
     "lerna": "^8.2.3",

--- a/packages/auth/firebase/package.json
+++ b/packages/auth/firebase/package.json
@@ -24,7 +24,7 @@
     "firebase-admin": "^12.0.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/google/package.json
+++ b/packages/auth/google/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/m365/package.json
+++ b/packages/auth/m365/package.json
@@ -25,7 +25,7 @@
     "jwks-rsa": "^3.1.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/auth/next/package.json
+++ b/packages/auth/next/package.json
@@ -24,7 +24,7 @@
     "jsonwebtoken": "^9.0.2"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/authz/mongodb/package.json
+++ b/packages/authz/mongodb/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/inmemory/package.json
+++ b/packages/memory/inmemory/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/memory/mongodb/package.json
+++ b/packages/memory/mongodb/package.json
@@ -31,7 +31,7 @@
     "mongoose": "^8.16.5"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/azure/index.ts
+++ b/packages/models/azure/index.ts
@@ -20,6 +20,7 @@ import type {
 	ToolCallDelta,
 } from "@ainetwork/adk/types/stream";
 import { loggers } from "@ainetwork/adk/utils/logger";
+import { messageToPromptText } from "@ainetwork/adk/utils/message-content";
 import { AzureOpenAI as AzureOpenAIClient } from "openai";
 import type {
 	ChatCompletionMessageParam as CCMessageParam,
@@ -128,11 +129,13 @@ export class AzureOpenAI extends BaseModel<CCMessageParam, ChatCompletionTool> {
 					// Prefer the real query stashed in metadata when a display text was
 					// shown in its place (displayQuery), so multi-turn history carries
 					// the actual query the model saw on the first turn — not the short
-					// label. Falls back to the stored content otherwise.
+					// label. Falls back to the stored content otherwise, flattened via
+					// messageToPromptText: `parts` is `unknown[]` and rich/document
+					// messages hold objects, which this API rejects as `content`.
 					const content =
 						typeof message.metadata?.query === "string"
 							? message.metadata.query
-							: (message.content.parts[0] as string);
+							: messageToPromptText(message);
 					return {
 						role: this.getMessageRole(message.role),
 						content,

--- a/packages/models/azure/package.json
+++ b/packages/models/azure/package.json
@@ -24,7 +24,7 @@
     "openai": "^6.9.1"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/models/azure/tests/generate-messages-history.test.ts
+++ b/packages/models/azure/tests/generate-messages-history.test.ts
@@ -63,4 +63,44 @@ describe("AzureOpenAI.generateMessages history reconstruction", () => {
 		const messages = provider.generateMessages({ query: "다음 질문", thread });
 		expect(messages.some((m) => m.content === "평범한 질문입니다")).toBe(true);
 	});
+
+	// Regression: a workflow run persists { type: "rich", parts: [DocumentPart] }
+	// with metadata.documentId but no metadata.query. Passing that part object
+	// through as `content` made the API reject the whole request with
+	// 400 "Invalid type for 'messages[N].content'", breaking every later turn.
+	it("never emits an object content for a workflow document message", () => {
+		const provider = makeProvider();
+		const thread = {
+			messages: [
+				{
+					messageId: "m1",
+					role: "MODEL" as MessageObject["role"],
+					timestamp: 1,
+					content: {
+						type: "rich",
+						parts: [
+							{ type: "document", documentId: "doc-1", title: "7월 리포트" },
+						],
+					},
+					metadata: {
+						workflowId: "w1",
+						workflowRun: true,
+						documentId: "doc-1",
+					},
+				},
+			],
+		} as unknown as ThreadObject;
+
+		const messages = provider.generateMessages({
+			query: "이어서 질문",
+			thread,
+		});
+
+		for (const message of messages) {
+			expect(typeof message.content).toBe("string");
+		}
+		expect(messages.some((m) => String(m.content).includes("7월 리포트"))).toBe(
+			true,
+		);
+	});
 });

--- a/packages/models/gemini/index.ts
+++ b/packages/models/gemini/index.ts
@@ -20,6 +20,7 @@ import type {
 	ToolCallDelta,
 } from "@ainetwork/adk/types/stream";
 import { loggers } from "@ainetwork/adk/utils/logger";
+import { messageToPromptText } from "@ainetwork/adk/utils/message-content";
 import {
 	type Content,
 	type FunctionCall,
@@ -148,15 +149,16 @@ export class GeminiModel extends BaseModel<Content, FunctionDeclaration> {
 		const sessionContent: Content[] = !thread
 			? []
 			: thread.messages.map((message: MessageObject) => {
-					// TODO: check message.content.type
 					// Prefer the real query stashed in metadata when a display text was
 					// shown in its place (displayQuery), so multi-turn history carries
 					// the actual query the model saw on the first turn — not the short
-					// label. Falls back to the stored content otherwise.
+					// label. Falls back to the stored content otherwise, flattened via
+					// messageToPromptText: `parts` is `unknown[]` and rich/document
+					// messages hold objects, which must never reach the API as text.
 					const text =
 						typeof message.metadata?.query === "string"
 							? message.metadata.query
-							: (message.content.parts[0] as string);
+							: messageToPromptText(message);
 					return {
 						role: this.getMessageRole(message.role),
 						parts: [{ text }],

--- a/packages/models/gemini/package.json
+++ b/packages/models/gemini/package.json
@@ -24,7 +24,7 @@
     "@google/genai": "^1.11.0"
   },
   "peerDependencies": {
-    "@ainetwork/adk": "^0.8.4"
+    "@ainetwork/adk": "^0.8.5"
   },
   "devDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
## Summary

The azure and gemini providers rebuilt chat history by reading `message.content.parts[0]` and asserting it to `string`. That assertion is false for workflow messages, and the resulting request was rejected outright — poisoning every subsequent turn in the thread. Both providers now flatten content through the ADK's `messageToPromptText`, with a regression test on the shape that broke.

## Root cause

History reconstruction assumed one content shape:

```ts
const content = typeof message.metadata?.query === "string"
    ? message.metadata.query
    : (message.content.parts[0] as string);   // ← not always a string
```

`parts` is typed `unknown[]`, and its element shape depends on `content.type`. A plain text turn holds a string, so the cast held in the common case. But a workflow run persists `{ type: "rich", parts: [DocumentPart] }` with `metadata.documentId` and **no** `metadata.query` — so the ternary fell to the cast and passed a *part object* through as `content`.

Azure rejects that with `400 Invalid type for 'messages[N].content'`. Because the rejection is about a persisted history message rather than the current input, **once a workflow had run in a thread, every later turn in that thread failed** — the thread was effectively bricked and no amount of retrying the new message helped. Gemini took the same path and would have put an object where its `parts[].text` declares a string.

## Fix

Both providers call `messageToPromptText(message)` (`@ainetwork/adk/utils/message-content`) for the fallback branch. It handles the rich/document shapes, renders document parts as a short label, and is total — malformed or unknown content yields `""` rather than a non-string value escaping into the request. `parts` keeps its honest `unknown[]` typing instead of being cast away.

The `metadata.query` preference is unchanged: when a display label was shown in place of the real query, history still carries the real one.

## Verification

- The new test fails without the fix and passes with it — confirmed by reverting `packages/models/azure/index.ts` alone and re-running (`typeof message.content` was not `"string"`).
- Full providers suite: **179 tests / 25 suites pass**.
- `tsup` builds succeed for `@ainetwork/adk-provider-model-azure` and `@ainetwork/adk-provider-model-gemini`.
- Biome clean on the changed files (only pre-existing `any` warnings elsewhere in the files).
- Gemini has no equivalent test file; its change is the same one-line substitution as azure's, covered by review rather than by a test.

## Depends on an unreleased ADK change — do not publish before it

`@ainetwork/adk/utils/message-content` was added in `ain-adk#feat/text-block-present-mode` and **is not in the published `0.8.4`**. These packages declare `@ainetwork/adk: ^0.8.4`, so publishing them against the registry version would break module resolution for external consumers.

Local CI passes only because the workspace pins `@ainetwork/adk` to `file:../ain-adk-v0` via `pnpm.overrides`, so the installed copy is the local checkout of that branch. Note that the installed `package.json` still reports `version: 0.8.4` — the version string does not describe the contents, so a green local run is not evidence that publishing is safe.

Required order:

1. Merge and release `ain-adk#feat/text-block-present-mode` (0.8.5+).
2. Bump the `@ainetwork/adk` peer range in the azure and gemini packages to that version.
3. Publish these packages.

Merging this PR ahead of the release is fine; publishing is what must wait.
